### PR TITLE
Update references to utility-scripts repo

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,7 +4,7 @@ Where a separate license is provided within a directory (as is the case, for exa
 
 ## Jcink Utility Scripts
 
-Jcink Utility Scripts by Coding Camp are used, but not included herein. A copy of the source may be downloaded from [GitHub](https://github.com/coding-camp-wiki/jcink-utility-scripts). This content is licensed under the [MIT License](https://github.com/coding-camp-wiki/jcink-utility-scripts/LICENSE).
+Jcink Utility Scripts by Coding Camp are used, but not included herein. A copy of the source may be downloaded from [GitHub](https://github.com/coding-camp-wiki/utility-scripts). This content is licensed under the [MIT License](https://github.com/coding-camp-wiki/utility-scripts/LICENSE).
 
 ## Work Sans Google Font
 

--- a/dist/html-templates/board_stats.html
+++ b/dist/html-templates/board_stats.html
@@ -1,5 +1,5 @@
 <script
-    src="https://coding-camp-wiki.github.io/jcink-utility-scripts/dist/move-recent-topics/move-recent-topics.js"
+    src="https://coding-camp-wiki.github.io/utility-scripts/dist/jcink/move-recent-topics/move-recent-topics.js"
     defer
 ></script>
 

--- a/dist/html-templates/memberlist_head.html
+++ b/dist/html-templates/memberlist_head.html
@@ -1,5 +1,5 @@
 <script
-    src="https://coding-camp-wiki.github.io/jcink-utility-scripts/dist/wrap-word/wrap-word.js"
+    src="https://coding-camp-wiki.github.io/utility-scripts/dist/wrap-word/wrap-word.js"
     defer
 ></script>
 


### PR DESCRIPTION
`coding-camp-wiki/jcink-utility-scripts` changed to `coding-camp-wiki/utility-scripts` and had some directory rearrangement done. Need to update to match.