### PR TITLE
Update URLs

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -25,7 +25,7 @@ Minus the above listed exceptions, all remaining content is licensed as follows:
 MIT License
 
 -   Modified and additional original work copyright (c) 2021 Coding Camp.
--   [Original base](https://codepen.io/summercodes/pen/poeVvrG) copyright (c) 2021 Summer .
+-   [Original base](https://codepen.io/summercodes/pen/poeVvrG) copyright (c) 2021 Summer.
 -   [Original board stats](https://codepen.io/Lissita/pen/poeqVev) copyright (c) 2021 Lissita.
 -   [Original category headers and forum, redirect, and topic rows](https://codepen.io/yorkupine/pen/YzZgWgG) copyright (c) 2021 Ray.
 -   [Original header and navigation](https://codepen.io/leeannflorez/pen/xxqmQNO) copyright (c) 2021 Leeann.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,7 +4,7 @@ Where a separate license is provided within a directory (as is the case, for exa
 
 ## Jcink Utility Scripts
 
-Jcink Utility Scripts by Coding Camp are used, but not included herein. A copy of the source may be downloaded from [GitHub](https://github.com/coding-camp-wiki/utility-scripts). This content is licensed under the [MIT License](https://github.com/coding-camp-wiki/utility-scripts/LICENSE).
+Jcink Utility Scripts by Coding Camp are used, but not included herein. A copy of the source may be downloaded from [GitHub](https://github.com/coding-camp-wiki/utility-scripts). This content is licensed under the [MIT License](https://github.com/coding-camp-wiki/utility-scripts/blob/main/LICENSE).
 
 ## Work Sans Google Font
 
@@ -12,7 +12,7 @@ Works Sans is used, but not included herein. A copy of the source may be downloa
 
 ## Mont by Fontfabric Type Foundry
 
-Mont by Fontfabric Type Foundry is included herein. A copy of the source may be downloaded from [dafont.com](https://www.dafont.com/mont.font). This content is licensed under the [FontFabric (tm) Free Font End User License Agreement (FFF EULA) ver. 2.0 June 2015](</dist/assets/fonts/mont/FFF EULA ver. 2.0 June 2015.pdf>).
+Mont by Fontfabric Type Foundry is included herein. A copy of the source may be downloaded from [dafont.com](https://www.dafont.com/mont.font). This content is licensed under the [FontFabric (tm) Free Font End User License Agreement (FFF EULA) ver. 2.0 June 2015](/dist/assets/fonts/mont/FFF EULA ver. 2.0 June 2015.pdf).
 
 ## Remix Icon
 
@@ -25,18 +25,18 @@ Minus the above listed exceptions, all remaining content is licensed as follows:
 MIT License
 
 -   Modified and additional original work copyright (c) 2021 Coding Camp.
--   Original base copyright (c) 2021 Summer (<https://codepen.io/summercodes/pen/poeVvrG>).
--   Original board stats copyright (c) 2021 Lissita (<https://codepen.io/Lissita/pen/poeqVev>).
--   Original category headers and forum, redirect, and topic rows copyright (c) 2021 Ray (<https://codepen.io/yorkupine/pen/YzZgWgG>).
--   Original header and navigation copyright (c) 2021 Leeann (<https://codepen.io/leeannflorez/pen/xxqmQNO>).
--   Original member list copyright (c) 2021 Rora (<https://codepen.io/aurorastralis/pen/vYxzbjx>).
--   Original main profile copyright (c) 2021 Monty (<https://codepen.io/MontyMouse/pen/mdWvOEg>).
--   Original mini-profile copyright (c) 2021 Abi (<https://codepen.io/hedgefruit/pen/poeqgBN>).
--   Original post row copyright (c) 2021 Juliet (<https://codepen.io/sea-witch/pen/KKWrYwP>).
--   Original site templates pack copyright (c) 2021 Leeann (<https://codepen.io/leeannflorez/pen/jOmymbL>).
--   Original roleplay templates packs copyright (c) 2021 Ally (<https://codepen.io/allycodes/pen/bGWGrzp>) and Jaslene (<https://codepen.io/jaslenejose/pen/mdmdGXo>).
--   Original development templates packs copyright (c) 2021 Izzy (<https://codepen.io/isabroch/pen/gOWOxZY>) and Rose💫 (<https://codepen.io/perfumeregret/pen/KKmKZdp>).
--   Original webpages copyright (c) 2021 Abi (<https://codepen.io/hedgefruit/pen/jOmbGrP>).
+-   Original base copyright (c) 2021 Summer (https://codepen.io/summercodes/pen/poeVvrG).
+-   Original board stats copyright (c) 2021 Lissita (https://codepen.io/Lissita/pen/poeqVev).
+-   Original category headers and forum, redirect, and topic rows copyright (c) 2021 Ray (https://codepen.io/yorkupine/pen/YzZgWgG).
+-   Original header and navigation copyright (c) 2021 Leeann (https://codepen.io/leeannflorez/pen/xxqmQNO).
+-   Original member list copyright (c) 2021 Rora (https://codepen.io/aurorastralis/pen/vYxzbjx).
+-   Original main profile copyright (c) 2021 Monty (https://codepen.io/MontyMouse/pen/mdWvOEg).
+-   Original mini-profile copyright (c) 2021 Abi (https://codepen.io/hedgefruit/pen/poeqgBN).
+-   Original post row copyright (c) 2021 Juliet (https://codepen.io/sea-witch/pen/KKWrYwP).
+-   Original site templates pack copyright (c) 2021 Leeann (https://codepen.io/leeannflorez/pen/jOmymbL).
+-   Original roleplay templates packs copyright (c) 2021 Ally (https://codepen.io/allycodes/pen/bGWGrzp) and Jaslene (https://codepen.io/jaslenejose/pen/mdmdGXo).
+-   Original development templates packs copyright (c) 2021 Izzy (https://codepen.io/isabroch/pen/gOWOxZY) and Rose💫 (https://codepen.io/perfumeregret/pen/KKmKZdp).
+-   Original webpages copyright (c) 2021 Abi (https://codepen.io/hedgefruit/pen/jOmbGrP).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -12,7 +12,7 @@ Works Sans is used, but not included herein. A copy of the source may be downloa
 
 ## Mont by Fontfabric Type Foundry
 
-Mont by Fontfabric Type Foundry is included herein. A copy of the source may be downloaded from [dafont.com](https://www.dafont.com/mont.font). This content is licensed under the [FontFabric (tm) Free Font End User License Agreement (FFF EULA) ver. 2.0 June 2015](/dist/assets/fonts/mont/FFF EULA ver. 2.0 June 2015.pdf).
+Mont by Fontfabric Type Foundry is included herein. A copy of the source may be downloaded from [dafont.com](https://www.dafont.com/mont.font). This content is licensed under the [FontFabric (tm) Free Font End User License Agreement (FFF EULA) ver. 2.0 June 2015](</dist/assets/fonts/mont/FFF EULA ver. 2.0 June 2015.pdf>).
 
 ## Remix Icon
 
@@ -25,18 +25,18 @@ Minus the above listed exceptions, all remaining content is licensed as follows:
 MIT License
 
 -   Modified and additional original work copyright (c) 2021 Coding Camp.
--   Original base copyright (c) 2021 Summer (https://codepen.io/summercodes/pen/poeVvrG).
--   Original board stats copyright (c) 2021 Lissita (https://codepen.io/Lissita/pen/poeqVev).
--   Original category headers and forum, redirect, and topic rows copyright (c) 2021 Ray (https://codepen.io/yorkupine/pen/YzZgWgG).
--   Original header and navigation copyright (c) 2021 Leeann (https://codepen.io/leeannflorez/pen/xxqmQNO).
--   Original member list copyright (c) 2021 Rora (https://codepen.io/aurorastralis/pen/vYxzbjx).
--   Original main profile copyright (c) 2021 Monty (https://codepen.io/MontyMouse/pen/mdWvOEg).
--   Original mini-profile copyright (c) 2021 Abi (https://codepen.io/hedgefruit/pen/poeqgBN).
--   Original post row copyright (c) 2021 Juliet (https://codepen.io/sea-witch/pen/KKWrYwP).
--   Original site templates pack copyright (c) 2021 Leeann (https://codepen.io/leeannflorez/pen/jOmymbL).
--   Original roleplay templates packs copyright (c) 2021 Ally (https://codepen.io/allycodes/pen/bGWGrzp) and Jaslene (https://codepen.io/jaslenejose/pen/mdmdGXo).
--   Original development templates packs copyright (c) 2021 Izzy (https://codepen.io/isabroch/pen/gOWOxZY) and Rose💫 (https://codepen.io/perfumeregret/pen/KKmKZdp).
--   Original webpages copyright (c) 2021 Abi (https://codepen.io/hedgefruit/pen/jOmbGrP).
+-   [Original base](https://codepen.io/summercodes/pen/poeVvrG) copyright (c) 2021 Summer .
+-   [Original board stats](https://codepen.io/Lissita/pen/poeqVev) copyright (c) 2021 Lissita.
+-   [Original category headers and forum, redirect, and topic rows](https://codepen.io/yorkupine/pen/YzZgWgG) copyright (c) 2021 Ray.
+-   [Original header and navigation](https://codepen.io/leeannflorez/pen/xxqmQNO) copyright (c) 2021 Leeann.
+-   [Original member list](https://codepen.io/aurorastralis/pen/vYxzbjx) copyright (c) 2021 Rora.
+-   [Original main profile](https://codepen.io/MontyMouse/pen/mdWvOEg) copyright (c) 2021 Monty.
+-   [Original mini-profile](https://codepen.io/hedgefruit/pen/poeqgBN) copyright (c) 2021 Abi.
+-   [Original post row](https://codepen.io/sea-witch/pen/KKWrYwP) copyright (c) 2021 Juliet.
+-   [Original site templates pack](https://codepen.io/leeannflorez/pen/jOmymbL) copyright (c) 2021 Leeann.
+-   Original roleplay templates packs ([1](https://codepen.io/allycodes/pen/bGWGrzp "Ally's original roleplay templates pack"), [2](https://codepen.io/jaslenejose/pen/mdmdGXo "Jaslene's original roleplay templates pack")) copyright (c) 2021 Ally and Jaslene.
+-   Original development templates packs ([1](https://codepen.io/isabroch/pen/gOWOxZY "Izzy's original development template pack"), [2](https://codepen.io/perfumeregret/pen/KKmKZdp "Rose💫's original development template pack")) copyright (c) 2021 Izzy and Rose💫.
+-   [Original Jcink webpages](https://codepen.io/hedgefruit/pen/jOmbGrP) copyright (c) 2021 Abi.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -56,7 +56,7 @@ Coding Camp info:
     font-style: normal;
     font-weight: 400 700;
     /* stylelint-disable indentation */
-    src: url(https://coding-camp.wiki/care-package-001/care-package-001/dist/assets/fonts/mont/mont-heavy-demo-webfont.woff2)
+    src: url(https://coding-camp.wiki/care-package-001/dist/assets/fonts/mont/mont-heavy-demo-webfont.woff2)
             format("woff2"),
         url(https://coding-camp.wiki/care-package-001/dist/assets/fonts/mont/mont-heavy-demo-webfont.woff)
             format("woff");

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -56,9 +56,9 @@ Coding Camp info:
     font-style: normal;
     font-weight: 400 700;
     /* stylelint-disable indentation */
-    src: url(https://coding-camp-wiki.github.io/care-package-001/dist/assets/fonts/mont/mont-heavy-demo-webfont.woff2)
+    src: url(https://coding-camp.wiki/care-package-001/care-package-001/dist/assets/fonts/mont/mont-heavy-demo-webfont.woff2)
             format("woff2"),
-        url(https://coding-camp-wiki.github.io/care-package-001/dist/assets/fonts/mont/mont-heavy-demo-webfont.woff)
+        url(https://coding-camp.wiki/care-package-001/dist/assets/fonts/mont/mont-heavy-demo-webfont.woff)
             format("woff");
     /* stylelint-enable indentation */
     unicode-range: U+0033-0034, U+0036, U+0038-0046, U+0048-0059, U+0061,

--- a/dist/assets/svg/remix-icon/LICENSE
+++ b/dist/assets/svg/remix-icon/LICENSE
@@ -1,7 +1,7 @@
                                    Remix Icon
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/dist/assets/svg/remix-icon/remix-icon.symbol.svg
+++ b/dist/assets/svg/remix-icon/remix-icon.symbol.svg
@@ -8,7 +8,7 @@
 
  Date: 2020-05-23
 -->
-<svg xmlns="http://www.w3.org/2000/svg" xlink="http://www.w3.org/1999/xlink" width="0" height="0" style="display:none;"><symbol viewBox="0 0 24 24" id="ri-24-hours-fill">
+<svg xmlns="https://www.w3.org/2000/svg" xlink="https://www.w3.org/1999/xlink" width="0" height="0" style="display:none;"><symbol viewBox="0 0 24 24" id="ri-24-hours-fill">
     <g>
         <path fill="none" d="M0 0H24V24H0z"/>
         <path d="M12 13c1.657 0 3 1.343 3 3 0 .85-.353 1.616-.92 2.162L12.17 20H15v2H9v-1.724l3.693-3.555c.19-.183.307-.438.307-.721 0-.552-.448-1-1-1s-1 .448-1 1H9c0-1.657 1.343-3 3-3zm6 0v4h2v-4h2v9h-2v-3h-4v-6h2zM4 12c0 2.527 1.171 4.78 3 6.246v2.416C4.011 18.933 2 15.702 2 12h2zm8-10c5.185 0 9.449 3.947 9.95 9h-2.012C19.446 7.054 16.08 4 12 4 9.536 4 7.332 5.114 5.865 6.865L8 9H2V3l2.447 2.446C6.28 3.336 8.984 2 12 2z"/>

--- a/dist/html-templates/board_stats.html
+++ b/dist/html-templates/board_stats.html
@@ -1,5 +1,5 @@
 <script
-    src="https://coding-camp-wiki.github.io/utility-scripts/dist/jcink/move-recent-topics/move-recent-topics.js"
+    src="https://coding-camp.wiki/utility-scripts/dist/jcink/move-recent-topics/move-recent-topics.js"
     defer
 ></script>
 

--- a/dist/html-templates/memberlist_head.html
+++ b/dist/html-templates/memberlist_head.html
@@ -1,7 +1,7 @@
 <!-- htmlhint input-requires-label:false -->
 
 <script
-    src="https://coding-camp-wiki.github.io/utility-scripts/dist/wrap-word/wrap-word.js"
+    src="https://coding-camp.wiki/utility-scripts/dist/wrap-word/wrap-word.js"
     defer
 ></script>
 


### PR DESCRIPTION
- Updates Camp wiki URLs to use custom domain (and therefore not be broken on the test site anymore). Closes #77 
- Fixes broken URL in license
- Upgrades `http` to `https` wherever that was hiding out