### PR TITLE
Add and improve link styling

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,7 @@
+# supported browsers
+
+> 5%
+last 2 versions
+Firefox ESR
+not dead
+not ie > 0

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -715,6 +715,11 @@ RAY'S CATEGORIES, FORUMS, TOPICS
     text-decoration: none;
 }
 
+.forum-last-post a:focus,
+.forum-last-post a:hover {
+    background-color: rgba(var(--pink), 0.7);
+}
+
 .subforums {
     padding: 1vw;
 }
@@ -727,6 +732,11 @@ RAY'S CATEGORIES, FORUMS, TOPICS
     margin: 1vw 0;
     padding: 0.2rem 0.5rem;
     text-decoration: none;
+}
+
+.subforums a.tooltip:focus,
+.subforums a.tooltip:hover {
+    background-color: var(--pink-hex);
 }
 
 .topic-row {

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -1568,6 +1568,8 @@ MONTY'S MAIN PROFILE
     right: auto;
 }
 
+.tab-forward:focus,
+.tab-back:focus,
 .tab-forward:hover,
 .tab-back:hover {
     background: linear-gradient(
@@ -1575,6 +1577,7 @@ MONTY'S MAIN PROFILE
         rgba(var(--green), 0.45),
         rgba(var(--yellow), 0.45)
     );
+    border-color: var(--blue-hex);
 }
 
 .dot-labels {

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -487,7 +487,6 @@ LEEANN'S HEADER & NAVIGATION
 }
 
 #header .info .links a:hover {
-    cursor: pointer;
     text-shadow: -1px -1px 0 var(--pink-hex), 0 -1px 0 var(--pink-hex),
         1px -1px 0 var(--pink-hex), 1px 0 0 var(--pink-hex),
         1px 1px 0 var(--pink-hex), 0 1px 0 var(--pink-hex),

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -486,6 +486,7 @@ LEEANN'S HEADER & NAVIGATION
     z-index: -1;
 }
 
+#header .info .links a:focus,
 #header .info .links a:hover {
     text-shadow: -1px -1px 0 var(--pink-hex), 0 -1px 0 var(--pink-hex),
         1px -1px 0 var(--pink-hex), 1px 0 0 var(--pink-hex),

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -1188,21 +1188,18 @@ JULIET'S POST ROW
     border: var(--black-hex) solid 2px;
     display: flex;
     font: 400 8px var(--sans);
+    gap: 15px;
     height: 30px;
     justify-content: center;
     letter-spacing: 2px;
     line-height: 90%;
     margin: -90px auto 75px 0;
-    padding: 0 0 0 15px;
+    padding-inline-end: 15px;
+    padding-inline-start: 15px;
     position: relative;
     text-transform: uppercase;
     width: max-content;
     z-index: 999;
-}
-
-.pr-wrap .pr-box .box-bord .box-edits span {
-    display: inline-block;
-    margin-right: 15px;
 }
 
 .pr-wrap .pr-box .box-bord .box-edits span:empty {

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -716,6 +716,10 @@ RAY'S CATEGORIES, FORUMS, TOPICS
     margin: 10px;
 }
 
+.topic-wrapper a:not(:hover):not(:focus) {
+    text-decoration-line: none;
+}
+
 .topic-wrapper .topic-title {
     font-family: var(--display);
     font-size: 2rem;
@@ -785,7 +789,6 @@ RAY'S CATEGORIES, FORUMS, TOPICS
     margin: 2px;
     min-width: 50%;
     text-align: center;
-    text-decoration: none;
 }
 
 .topic-wrapper .topic-starter {

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -731,10 +731,10 @@ RAY'S CATEGORIES, FORUMS, TOPICS
     gap: 1vw 2vw;
     grid-area: topic-info;
     grid-template-areas:
-        "topic-desc topic-desc topic-desc topic-desc"
-        "topic-last-post-av topic-last-post topic-last-post topic-last-post"
-        "topic-starter topic-starter topic-starter topic-starter"
-        "topic-pagination topic-pagination topic-pagination topic-pagination";
+        "topic-desc         topic-desc          topic-desc          topic-desc"
+        "topic-last-post-av topic-last-post     topic-last-post     topic-last-post"
+        "topic-starter      topic-starter       topic-starter       topic-starter"
+        "topic-pagination   topic-pagination    topic-pagination    topic-pagination";
     grid-template-columns: auto 1fr 1fr 1fr;
     grid-template-rows: repeat(3, auto) 1fr;
 }

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -4088,13 +4088,18 @@ ABI'S WEBPAGES
     line-height: 2.5;
     padding-left: 10px;
     padding-right: 10px;
-    text-decoration: none;
     text-transform: uppercase;
     transition: 1s ease;
 }
 
+.webpagesidebar .webpagesidebarcont a:not(:focus):not(:hover) {
+    text-decoration-color: transparent;
+}
+
+.webpagesidebar .webpagesidebarcont a:focus,
 .webpagesidebar .webpagesidebarcont a:hover {
     letter-spacing: 2px;
+    text-decoration-line: underline;
     transition: 1s ease;
 }
 

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -1813,6 +1813,7 @@ RORA'S MEMBER LIST
     transition: var(--transi-quick);
 }
 
+.cp-memsearch .forminput.submit:focus,
 .cp-memsearch .forminput.submit:hover {
     background: var(--pink-hex);
     transition: var(--transi-quick);

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -1471,12 +1471,14 @@ MONTY'S MAIN PROFILE
     transition: 0.3s;
 }
 
+.main-links a:focus,
 .main-links a:hover {
     background: linear-gradient(
         to left,
         rgba(var(--green), 0.45),
         rgba(var(--yellow), 0.45)
     );
+    border-color: var(--blue-hex);
 }
 
 .main-inner-account {

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -95,12 +95,6 @@ body {
     --white: 249, 247, 246;
     --white-hex: #f6f8f8;
 
-    /* SHADOWS */
-    --pink-text-shadow: -1px -1px 0 var(--pink-hex), -1px 0 0 var(--pink-hex),
-        -1px 1px 0 var(--pink-hex), 0 -1px 0 var(--pink-hex),
-        0 1px 0 var(--pink-hex), 1px -1px 0 var(--pink-hex),
-        1px 0 0 var(--pink-hex), 1px 1px 0 var(--pink-hex);
-
     /* BACKGROUND GRADIENTS */
     --green-radial-gradient: radial-gradient(
         circle at top right,
@@ -236,8 +230,8 @@ a {
 
 a:focus,
 a:hover {
-    text-decoration-color: var(--pink-hex);
-    text-shadow: var(--pink-text-shadow);
+    text-decoration-color: var(--blue-hex);
+    text-decoration-line: underline overline;
 }
 
 img {

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -717,7 +717,7 @@ RAY'S CATEGORIES, FORUMS, TOPICS
     margin: 10px;
 }
 
-.topic-wrapper a:not(:hover):not(:focus) {
+.topic-wrapper a:not(:focus):not(:hover) {
     text-decoration-line: none;
 }
 

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -2408,6 +2408,8 @@ LEEANN'S SITE PACK
     width: 100%;
 }
 
+.box-post .cc-fc .text col-1 a:focus .x,
+.box-post .cc-fc .text col-2 a:focus .x,
 .box-post .cc-fc .text col-1 a:hover .x,
 .box-post .cc-fc .text col-2 a:hover .x {
     opacity: 0;
@@ -2416,6 +2418,8 @@ LEEANN'S SITE PACK
     width: 100%;
 }
 
+.box-post .cc-fc .text col-1 a:focus .y,
+.box-post .cc-fc .text col-2 a:focus .y,
 .box-post .cc-fc .text col-1 a:hover .y,
 .box-post .cc-fc .text col-2 a:hover .y {
     background: var(--black-hex);
@@ -2481,6 +2485,8 @@ LEEANN'S SITE PACK
     width: 80%;
 }
 
+.box-post .cc-md .text col-1 a:focus,
+.box-post .cc-md .text col-2 a:focus,
 .box-post .cc-md .text col-1 a:hover,
 .box-post .cc-md .text col-2 a:hover {
     background: var(--black-hex);

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -224,6 +224,7 @@ ELEMENTS
 a {
     color: inherit;
     text-decoration-color: rgba(var(--black), 0.3);
+
     /* skip-ink, thickness, and offset may not work everywhere, but fallback just fine */
     text-decoration-skip-ink: auto;
     text-decoration-thickness: 0.1em;

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -224,8 +224,10 @@ ELEMENTS
 a {
     color: inherit;
     text-decoration-color: rgba(var(--black), 0.3);
-    text-decoration-thickness: 10%;
-    text-underline-offset: 10%;
+    /* skip-ink, thickness, and offset may not work everywhere, but fallback just fine */
+    text-decoration-skip-ink: auto;
+    text-decoration-thickness: 0.1em;
+    text-underline-offset: 0.1em;
 }
 
 a:focus,

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -3668,12 +3668,25 @@ IZZY'S DEV PACK
 .dev-tracker .thread {
     --color: var(--black-hex);
 
-    border-right: 2px solid var(--color);
     margin: 16px 16px 16px 24px;
     position: relative;
 }
 
-.dev-tracker .thread::after {
+.dev-tracker .thread-name {
+    border-right: 2px solid var(--color);
+    color: var(--color);
+    display: block;
+    font-weight: 500;
+    letter-spacing: 0.1px;
+    padding: 4px 16px 16px 8px;
+}
+
+.dev-tracker .thread-name:focus,
+.dev-tracker .thread-name:hover {
+    --color: var(--group);
+}
+
+.dev-tracker .thread-name::after {
     border-bottom: 2px solid var(--color);
     bottom: 8px;
     content: "";
@@ -3682,18 +3695,6 @@ IZZY'S DEV PACK
     pointer-events: none;
     position: absolute;
     right: -8px;
-}
-
-.dev-tracker .thread:hover {
-    --color: var(--group);
-}
-
-.dev-tracker .thread-name {
-    color: var(--color);
-    display: block;
-    font-weight: 500;
-    letter-spacing: 0.1px;
-    padding: 4px 16px 16px 8px;
 }
 
 /*

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -3945,7 +3945,7 @@ ROSE'S DEV PACK
     color: var(--white-hex);
     font-size: 10px;
     font-weight: bold;
-    text-decoration: none;
+    text-decoration-color: currentColor;
     text-transform: uppercase;
 }
 

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -95,6 +95,12 @@ body {
     --white: 249, 247, 246;
     --white-hex: #f6f8f8;
 
+    /* SHADOWS */
+    --pink-text-shadow: -1px -1px 0 var(--pink-hex), -1px 0 0 var(--pink-hex),
+        -1px 1px 0 var(--pink-hex), 0 -1px 0 var(--pink-hex),
+        0 1px 0 var(--pink-hex), 1px -1px 0 var(--pink-hex),
+        1px 0 0 var(--pink-hex), 1px 1px 0 var(--pink-hex);
+
     /* BACKGROUND GRADIENTS */
     --green-radial-gradient: radial-gradient(
         circle at top right,
@@ -220,6 +226,19 @@ body {
 ELEMENTS
 -----
 */
+
+a {
+    color: inherit;
+    text-decoration-color: rgba(var(--black), 0.3);
+    text-decoration-thickness: 10%;
+    text-underline-offset: 10%;
+}
+
+a:focus,
+a:hover {
+    text-decoration-color: var(--pink-hex);
+    text-shadow: var(--pink-text-shadow);
+}
 
 img {
     max-inline-size: 100%;

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -326,46 +326,6 @@ LEEANN'S HEADER & NAVIGATION
     margin-right: 5rem;
 }
 
-#topbar .toplinks #myLinks {
-    background: var(--black-hex);
-    display: none;
-    max-width: 80%;
-    position: absolute;
-    right: 0;
-    top: 51px;
-    width: 200px;
-}
-
-#topbar .toplinks:hover #myLinks,
-#topbar .toplinks:focus-within #myLinks {
-    display: initial;
-}
-
-#topbar .toplinks a,
-#topbar .toplinks .icon {
-    color: var(--white-hex);
-    display: block;
-    fill: var(--white-hex);
-    font-size: 17px;
-    padding: 14px 16px;
-    text-decoration: none;
-}
-
-#topbar .toplinks .icon {
-    background: var(--black-hex);
-    display: block;
-    position: absolute;
-    right: 0;
-    top: 0;
-}
-
-#topbar .toplinks a:hover,
-#topbar .toplinks .icon:hover {
-    background-color: var(--white-hex);
-    color: var(--black-hex);
-    fill: var(--black-hex);
-}
-
 #sidebar {
     background: var(--white-hex);
     display: grid;

--- a/dist/assets/stylesheet.css
+++ b/dist/assets/stylesheet.css
@@ -2592,8 +2592,11 @@ LEEANN'S SITE PACK
     color: var(--black-hex);
     font: 400 1.5rem var(--display);
     letter-spacing: 1px;
-    text-decoration: none;
     text-transform: uppercase;
+}
+
+.box-post .cc-md-rep .body .char char-name a:not(:focus):not(:hover) {
+    text-decoration-line: none;
 }
 
 .box-post .cc-md-rep .body .char char-info {

--- a/dist/html-templates/topic_row.html
+++ b/dist/html-templates/topic_row.html
@@ -1,22 +1,27 @@
 <div class="topic-wrapper">
     <div class="topic-title">
         <!-- |prefix| -->
-        <!-- |topic| -->
+        <a href="<!-- |topic_url| -->"><!-- |topic_text| --></a>
+        <!-- |mod_checkbox| -->
     </div>
 
     <div class="topic-info">
         <div class="topic-desc"><!-- |topic_desc| --></div>
+
         <div class="topic-last-post-av">
             <!-- |last_poster_avatar| -->
         </div>
+
         <div class="topic-last-post">
             last post by:
             <!-- |last_poster| -->
         </div>
+
         <div class="topic-starter">
             topic started by:
             <!-- |starter| -->
         </div>
+
         <div class="topic-pagination">
             <!-- |pages| -->
             <div class="views-replies-flex">
@@ -32,6 +37,4 @@
             </div>
         </div>
     </div>
-
-    <!-- |mod_checkbox| -->
 </div>


### PR DESCRIPTION
- Adds default link styling. Closes #34.
- Also applies `:hover` styles on `:focus`
- Makes sure that links are obviously links
- Makes sure that hovered or focused links stand out as such
- Closes #33 