### PR TITLE
Update wrap-word.js usage, pin scripts

### DIFF
--- a/dist/html-templates/board_stats.html
+++ b/dist/html-templates/board_stats.html
@@ -1,5 +1,7 @@
 <script
-    src="https://coding-camp.wiki/utility-scripts/dist/jcink/move-recent-topics/move-recent-topics.js"
+    crossorigin="anonymous"
+    integrity="sha384-L+FYXjjhdyqYxmzto4xRgxK/0FgEzMtwbJ3KgHtQ88L/jUOepLPaenhVWWagbTCQ"
+    src="https://cdn.jsdelivr.net/gh/coding-camp-wiki/utility-scripts@4.0.0/dist/jcink/move-recent-topics/move-recent-topics.js"
     defer
 ></script>
 

--- a/dist/html-templates/memberlist_head.html
+++ b/dist/html-templates/memberlist_head.html
@@ -2,8 +2,8 @@
 
 <script
     crossorigin="anonymous"
-    integrity="sha384-APVxhFlPnbOKVXORQ0iY5us+smZ/9qIOvNuAe+TJBWlWSD9ZxpVuo2cfd7PBCHxX"
-    src="https://coding-camp.wiki/utility-scripts/dist/wrap-word/wrap-word.js"
+    integrity="sha384-bCDTvaqaNhNcBo3FUsavg8K4io9YjvqivetmgvyqsA+ABt8bU1IfiCVwZr5hZjh9"
+    src="https://cdn.jsdelivr.net/gh/coding-camp-wiki/utility-scripts@4.0.0/dist/wrap-word/wrap-word.js"
     defer
 ></script>
 

--- a/dist/html-templates/memberlist_row.html
+++ b/dist/html-templates/memberlist_row.html
@@ -15,7 +15,7 @@
 
         <div class="membord"><span></span></div>
 
-        <div class="cp-memname" data-trigger-word-wrap="last">
+        <div class="cp-memname" data-js-trigger-word-wrap="last">
             <!-- |member_name| -->
         </div>
 


### PR DESCRIPTION
* Updates usage of `wrap-word.js` script to handle [breaking changes](https://github.com/coding-camp-wiki/utility-scripts/releases/tag/v4.0.0)
* Pins `wrap-word.js` to v4.0.0
* Pins `move-recent-topics.js` to v4.0.0
* Add subresource integrity checks to `move-recent-topics.js`

