### PR TITLE
Update outdated utility script URLs

### DIFF
--- a/dist/html-templates/board_stats.html
+++ b/dist/html-templates/board_stats.html
@@ -1,7 +1,6 @@
 <script
     crossorigin="anonymous"
-    integrity="sha384-L+FYXjjhdyqYxmzto4xRgxK/0FgEzMtwbJ3KgHtQ88L/jUOepLPaenhVWWagbTCQ"
-    src="https://cdn.jsdelivr.net/gh/coding-camp-wiki/utility-scripts@4.0.0/dist/jcink/move-recent-topics/move-recent-topics.js"
+    src="https://cdn.jsdelivr.net/gh/rp-magrathea/bracca@5/dist/jcink/move-recent-topics/index.js"
     defer
 ></script>
 

--- a/dist/html-templates/memberlist_head.html
+++ b/dist/html-templates/memberlist_head.html
@@ -2,8 +2,7 @@
 
 <script
     crossorigin="anonymous"
-    integrity="sha384-bCDTvaqaNhNcBo3FUsavg8K4io9YjvqivetmgvyqsA+ABt8bU1IfiCVwZr5hZjh9"
-    src="https://cdn.jsdelivr.net/gh/coding-camp-wiki/utility-scripts@4.0.0/dist/wrap-word/wrap-word.js"
+    src="https://cdn.jsdelivr.net/gh/rp-magrathea/bracca@5/dist/wrap-word/index.js"
     defer
 ></script>
 


### PR DESCRIPTION
For the `move-recent-topics` and `wrap-word` scripts.

Pinning to major version only to allow for bug fixes and non-breaking updates to trickle in automatically.