### PR TITLE
Remove excess whitespace from SVG titles

### DIFF
--- a/dist/html-templates/profile.html
+++ b/dist/html-templates/profile.html
@@ -60,9 +60,9 @@
                     class="block-icon"
                     role="button"
                 >
-                    <title id="tab-1-forward-title">
-                        Move forward to Character tab
-                    </title>
+                    <!-- note: whitespace inside titles shows up in tooltips -->
+                    <!-- prettier-ignore -->
+                    <title id="tab-1-forward-title">Move forward to Character tab</title>
                     <use
                         href="/uploads2/codingcamp/svg/remix_icon_symbol.svg#ri-arrow-right-s-line"
                     ></use>
@@ -74,9 +74,8 @@
                     class="block-icon"
                     role="button"
                 >
-                    <title id="tab-2-forward-title">
-                        Move forward to Freeform tab
-                    </title>
+                    <!-- prettier-ignore -->
+                    <title id="tab-2-forward-title">Move forward to Freeform tab</title>
                     <use
                         href="/uploads2/codingcamp/svg/remix_icon_symbol.svg#ri-arrow-right-s-line"
                     ></use>
@@ -88,9 +87,8 @@
                     class="block-icon"
                     role="button"
                 >
-                    <title id="tab-3-forward-title">
-                        Move forward to Player tab
-                    </title>
+                    <!-- prettier-ignore -->
+                    <title id="tab-3-forward-title">Move forward to Player tab</title>
                     <use
                         href="/uploads2/codingcamp/svg/remix_icon_symbol.svg#ri-arrow-right-s-line"
                     ></use>
@@ -103,9 +101,8 @@
                     class="block-icon"
                     role="button"
                 >
-                    <title id="tab-1-backward-title">
-                        Move backward to Character tab
-                    </title>
+                    <!-- prettier-ignore -->
+                    <title id="tab-1-backward-title">Move backward to Character tab</title>
                     <use
                         href="/uploads2/codingcamp/svg/remix_icon_symbol.svg#ri-arrow-left-s-line"
                     ></use>
@@ -117,9 +114,8 @@
                     class="block-icon"
                     role="button"
                 >
-                    <title id="tab-2-backward-title">
-                        Move backward to Freeform tab
-                    </title>
+                    <!-- prettier-ignore -->
+                    <title id="tab-2-backward-title">Move backward to Freeform tab</title>
                     <use
                         href="/uploads2/codingcamp/svg/remix_icon_symbol.svg#ri-arrow-left-s-line"
                     ></use>
@@ -131,9 +127,8 @@
                     class="block-icon"
                     role="button"
                 >
-                    <title id="tab-3-backward-title">
-                        Move backward to Player tab
-                    </title>
+                    <!-- prettier-ignore -->
+                    <title id="tab-3-backward-title">Move backward to Player tab</title>
                     <use
                         href="/uploads2/codingcamp/svg/remix_icon_symbol.svg#ri-arrow-left-s-line"
                     ></use>


### PR DESCRIPTION
And don't let Prettier put it back in because it shows up in tooltips.

Closes #59.